### PR TITLE
Change plugin name and ID to be Wuhsu specific

### DIFF
--- a/plugin-unity-common/src/main/kotlin/jetbrains/buildServer/unity/UnityConstants.kt
+++ b/plugin-unity-common/src/main/kotlin/jetbrains/buildServer/unity/UnityConstants.kt
@@ -22,12 +22,12 @@ import jetbrains.buildServer.agent.Constants
  * Cargo runner constants.
  */
 object UnityConstants {
-    const val RUNNER_TYPE = "unity"
-    const val RUNNER_DISPLAY_NAME = "Unity"
+    const val RUNNER_TYPE = "unity_wushu"
+    const val RUNNER_DISPLAY_NAME = "Unity by Wushu"
     const val RUNNER_DESCRIPTION = "Provides build support for Unity projects"
     const val BUILD_FEATURE_TYPE = "UnityBuildFeature"
     const val BUILD_FEATURE_DISPLAY_NAME = "Unity build settings"
-    const val UNITY_CONFIG_NAME = "$RUNNER_TYPE.path."
+    const val UNITY_CONFIG_NAME = "unity.path."
 
     const val PARAM_PROJECT_PATH = "projectPath"
     const val PARAM_EXECUTE_METHOD = "executeMethod"

--- a/plugin-unity-server/teamcity-plugin.xml
+++ b/plugin-unity-server/teamcity-plugin.xml
@@ -15,18 +15,20 @@
   ~ limitations under the License.
   -->
 
-<teamcity-plugin xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:noNamespaceSchemaLocation="urn:shemas-jetbrains-com:teamcity-plugin-v1-xml">
-    <info>
-        <name>unity</name>
-        <display-name>Unity Support</display-name>
-        <version>@Plugin_Version@</version>
-        <description>Provides build facilities for Unity projects</description>
-        <vendor>
-            <name>JetBrains</name>
-            <url>http://www.jetbrains.com/</url>
-        </vendor>
-    </info>
-    <requirements min-build="40000" />
-    <deployment use-separate-classloader="true"/>
+<teamcity-plugin
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="urn:shemas-jetbrains-com:teamcity-plugin-v1-xml">
+	<info>
+		<name>unity_Wushu</name>
+		<display-name>Unity Support by Wushu</display-name>
+		<version>SNAPSHOT-01</version>
+		<description>Provides improved build facilities for Unity projects,
+			based on offical plugin</description>
+		<vendor>
+			<name>Wuhsu Studios</name>
+			<url>https://github.com/wushustudios/teamcity-unity-plugin</url>
+		</vendor>
+	</info>
+	<requirements min-build="40000" />
+	<deployment use-separate-classloader="true" />
 </teamcity-plugin>


### PR DESCRIPTION
The Pull Request updates the name and ID of the plugin. This is required so Teamcity can have both this plugin and Unity plugin installed at the same time 